### PR TITLE
Use `command` to check if the editor is available

### DIFF
--- a/lib/dotgpg.rb
+++ b/lib/dotgpg.rb
@@ -34,7 +34,7 @@ class Dotgpg
 
   def self.guess_editor
     %w(subl sublime-text sensible-editor editor mate nano vim vi open).detect do |editor|
-      system("which #{editor} > /dev/null 2>&1")
+      system("command -v #{editor} > /dev/null 2>&1")
     end
   end
 


### PR DESCRIPTION
I recently looked into a lot of shell stuff, especially what really is POSIX-compatible and the best ways to do several things.
From what I found it's best to not use `which`, but instead shell built-ins to determine if a command is available. `command` is available everywhere, fully specified in POSIX and will definitely set the correct exit code. Read [Stack Overflow](http://stackoverflow.com/questions/592620/how-to-check-if-a-program-exists-from-a-bash-script/677212#677212) for more.
I proposed a similar solution at two other projects ([gpm, issue #24](https://github.com/pote/gpm/pull/24) and for the redis `install_server.sh` script)

Thanks for this project, it might come in handy for me.
