### PR TITLE
Dup frozen editor variable

### DIFF
--- a/lib/dotgpg.rb
+++ b/lib/dotgpg.rb
@@ -20,6 +20,7 @@ class Dotgpg
   # https://github.com/pry/pry/blob/master/LICENSE
   def self.editor
     configured = ENV["VISUAL"] || ENV["EDITOR"] || guess_editor
+    configured = configured.dup
     case configured
     when /^mate/, /^subl/
       configured << " -w"


### PR DESCRIPTION
Was receiving: `dotgpg/lib/dotgpg.rb:25:in 'editor': can't modify frozen String (RuntimeError)`.

Running Ruby 2.1.1.
