### PR TITLE
`init` does not overide exist README.md.

### DIFF
--- a/lib/dotgpg/cli.rb
+++ b/lib/dotgpg/cli.rb
@@ -19,12 +19,14 @@ class Dotgpg
       key = Dotgpg::Key.secret_key(options[:email], options[:"new-key"])
 
       info "Initializing new dotgpg directory"
-      info "  #{directory}/README.md"
+      info "  #{directory}/README.md" unless File.exist? 'README.md'
       info "  #{directory}/.gpg/#{key.email}"
 
       FileUtils.mkdir_p(dir.dotgpg)
-      FileUtils.cp Pathname.new(__FILE__).dirname.join("template/README.md"), dir.path.join("README.md")
+      unless File.exist? 'README.md'      
+        FileUtils.cp Pathname.new(__FILE__).dirname.join("template/README.md"), dir.path.join("README.md")
       dir.add_key(key)
+      end
     end
 
     desc "key", "export your GPG public key in a format that `dotgpg add` will understand"

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -30,6 +30,11 @@ describe Dotgpg::Cli do
       assert_equal $fixture.join("create-3", ".gpg", "test@example.com").read, GPGME::Key.find(:secret).first.export(armor: true).to_s
     end
 
+    it "should not add a README if there is already one" do |variable|
+      FileUtils.touch 'README.md'
+      assert_not_equal File.read('README.md'), File.read($basic + 'README.md')
+    end
+
     it "should fail if the .gpg directory already exists" do
       FileUtils.mkdir_p $fixture + "create-4" + ".gpg"
       assert_fails(/\.gpg already exists/) do


### PR DESCRIPTION
When invoking `dotgpg init`, check if a README.md already exist.
If so, do not create a README.md.
This avoids overide exist README.md in the directory.
