### PR TITLE
Fix creating keys from CLI

### DIFF
--- a/dotgpg.gemspec
+++ b/dotgpg.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name = 'dotgpg'
-  gem.version = '0.6.0'
+  gem.version = '0.6.1'
 
   gem.summary = 'gpg-encrypted backup for your dotenv files'
   gem.description = "Easy management of gpg-encrypted backup files"

--- a/lib/dotgpg/cli.rb
+++ b/lib/dotgpg/cli.rb
@@ -25,8 +25,8 @@ class Dotgpg
       FileUtils.mkdir_p(dir.dotgpg)
       unless File.exist? 'README.md'
         FileUtils.cp Pathname.new(__FILE__).dirname.join("template/README.md"), dir.path.join("README.md")
-      dir.add_key(key)
       end
+      dir.add_key(key)
     end
 
     desc "key", "export your GPG public key in a format that `dotgpg add` will understand"


### PR DESCRIPTION
If I already have a `README.md` file in my repo, when I run `dotgpg init`, the `.gpg` directory is created, but the key for my email address is not. This is because the call to `dir.add_key(key)` is inside the conditional block `unless File.exist? 'README.md'`